### PR TITLE
Allow OPAM local switch when checking compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ clean:
 tests.byte: letrec.cma lib_test/tests.ml
 
 check-compiler:
-	@test $$(opam switch  show) = "4.07.1+BER"  \
-      || test $$(opam switch  show) = "4.04.0+BER"  \
+	@test $$(opam show ocaml-variants --field=installed-version) = "4.07.1+BER"  \
+      || test $$(opam show ocaml-variants --field=installed-version) = "4.04.0+BER"  \
       || (echo 1>&2 "Please use OPAM switch 4.04.0+BER or 4.07.1+BER"; exit 1)
 
 .PHONY: check-compiler all clean test


### PR DESCRIPTION
I modify Makefile to allow [OPAM local switch](https://opam.ocaml.org/blog/opam-local-switches/) when checking compiler version.

With OPAM local switch, its switch name is the same as a file path of its local directory even if its compiler is 4.07.1+BER or 4.04.0+BER. Therefore `make` fails if using local switch:

```
metaocaml-letrec$ opam switch create . 4.07.1+BER --deps-only
(snip.)
metaocaml-letrec$ opam install .
[WARNING] Failed checks on letrec package definition from source at
          git+file:///mnt/c/Users/nek/dev/src/github.com/yallop/metaocaml-letrec#master:
  warning 48: The fields 'build-test:' and 'build-doc:' are deprecated, and should be replaced by uses of the
              'with-test' and 'with-doc' filter variables in the 'build:' and 'install:' fields, and by the newer
              'run-test:' field
letrec is now pinned to git+file:///mnt/c/Users/nek/dev/src/github.com/yallop/metaocaml-letrec#master (version ~dev)
The following actions will be performed:
  ∗ install letrec ~dev*


<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[letrec.~dev] synchronised from git+file:///mnt/c/Users/nek/dev/src/github.com/yallop/metaocaml-letrec#master

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[ERROR] The compilation of letrec failed at "/home/nek/.opam/opam-init/hooks/sandbox.sh build make".

#=== ERROR while compiling letrec.~dev ========================================#
# context     2.0.7 | linux/x86_64 | ocaml-variants.4.07.1+BER | pinned(git+file:///mnt/c/Users/nek/dev/src/github.com/yallop/metaocaml-letrec#master#e4265180)
# path        /mnt/c/Users/nek/dev/src/github.com/yallop/metaocaml-letrec/_opam/.opam-switch/build/letrec.~dev
# command     ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code   2
# env-file    ~/.opam/log/letrec-31698-c743ac.env
# output-file ~/.opam/log/letrec-31698-c743ac.out
### output ###
# Please use OPAM switch 4.04.0+BER or 4.07.1+BER
# Makefile:40: recipe for target 'check-compiler' failed
# make: *** [check-compiler] Error 1



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
┌─ The following actions failed
│ λ build letrec ~dev
└─
╶─ No changes have been performed
```

This pull request finds the compiler version using `opam show` instead of `opam switch`.

`opam show ocaml-variants -f installed-version` shows its version string if installed, or shows `--` if not installed.

(By the way, IMO, this check is redundant because compiler dependency is also checked by OPAM when running `opam install`.)